### PR TITLE
Add express 48h vinyl presets and link from builder

### DIFF
--- a/assets/sticker-builder.css
+++ b/assets/sticker-builder.css
@@ -1041,3 +1041,276 @@ body.stb-lock{ overflow:hidden }
 .stb-quote-popup .btn.btn-primary:focus-visible{ box-shadow:0 0 0 3px rgba(255,255,255,.3),0 0 0 5px var(--focus-ring); }
 .stb-quote-popup__dialog:focus-visible{ outline:none; box-shadow:0 0 0 3px var(--focus-ring); }
 
+
+/* ===== Link promujący tryb ekspres ===== */
+.stb-standard-banner{
+  background:linear-gradient(90deg,rgba(243,131,27,.12) 0%,rgba(255,203,0,.18) 100%);
+  border:1px solid rgba(243,131,27,.35);
+  border-radius:14px;
+  padding:14px 18px;
+  margin:0 auto 18px;
+  max-width:1000px;
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  gap:8px 14px;
+  font-size:.95rem;
+}
+.stb-standard-banner strong{
+  color:#c2660d;
+  letter-spacing:.03em;
+  text-transform:uppercase;
+  font-size:.78rem;
+}
+.stb-standard-banner a{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:6px 14px;
+  background:#F3831B;
+  color:#fff !important;
+  border-radius:999px;
+  font-weight:700;
+  text-decoration:none;
+  transition:background .18s, box-shadow .18s;
+}
+.stb-standard-banner a::after{ content:'→'; font-size:.95rem; }
+.stb-standard-banner a:hover{ background:#ff941f; box-shadow:0 8px 24px rgba(243,131,27,.25); }
+.stb-standard-banner a:focus-visible{ outline:none; box-shadow:0 0 0 4px rgba(255,255,255,.6),0 0 0 6px rgba(243,131,27,.4); }
+
+/* ===== Express 48h Landing ===== */
+#stb-express-root{
+  --exp-accent:#F3831B;
+  --exp-accent-dark:#c2660d;
+  --exp-muted:#6f6f7a;
+  --exp-line:#e9e9f2;
+  --exp-card:#fff;
+  font-family:Inter,system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+  color:#101221;
+  padding:32px 16px 48px;
+  background:#f8f9fc;
+}
+#stb-express-root *{ box-sizing:border-box; }
+#stb-express-root h1,#stb-express-root h2,#stb-express-root h3,#stb-express-root p,#stb-express-root a,#stb-express-root span,#stb-express-root li,#stb-express-root button{
+  font-family:inherit;
+}
+#stb-express-root .stb-express-hero{
+  max-width:980px;
+  margin:0 auto 32px;
+  background:radial-gradient(circle at 10% 20%, rgba(255,203,0,.26), rgba(255,255,255,0) 55%), #fff6e8;
+  border-radius:20px;
+  border:1px solid rgba(243,131,27,.25);
+  padding:32px 36px;
+}
+#stb-express-root .stb-express-hero__copy h1{
+  margin:0 0 12px;
+  font-size:2.1rem;
+  line-height:1.2;
+}
+#stb-express-root .stb-express-hero__copy strong{ color:var(--exp-accent-dark); }
+#stb-express-root .stb-express-hero__lead{
+  margin:0 0 18px;
+  font-size:1.08rem;
+  color:var(--exp-muted);
+}
+#stb-express-root .stb-express-hero__sla{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px 18px;
+  margin:0;
+  padding:0;
+  list-style:none;
+  font-size:.92rem;
+  color:#2f3342;
+}
+#stb-express-root .stb-express-hero__sla li{
+  display:flex;
+  align-items:center;
+  gap:6px;
+}
+#stb-express-root .stb-express-hero__sla li::before{
+  content:'•';
+  font-size:1.1rem;
+  color:var(--exp-accent-dark);
+}
+
+#stb-express-root .stb-express-mode{ max-width:980px; margin:0 auto 28px; }
+#stb-express-root .stb-express-mode__grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(260px,1fr)); gap:18px; }
+#stb-express-root .stb-express-mode__card{
+  background:var(--exp-card);
+  border:1px solid var(--exp-line);
+  border-radius:18px;
+  padding:24px 26px;
+  display:grid;
+  gap:12px;
+  text-decoration:none;
+  color:inherit;
+  transition:box-shadow .2s, transform .2s, border-color .2s;
+}
+#stb-express-root .stb-express-mode__card header{ display:grid; gap:6px; }
+#stb-express-root .stb-express-mode__card h2{ margin:0; font-size:1.24rem; }
+#stb-express-root .stb-express-mode__eyebrow{ margin:0; text-transform:uppercase; font-size:.72rem; letter-spacing:.12em; color:var(--exp-accent-dark); font-weight:700; }
+#stb-express-root .stb-express-mode__card ul{ margin:0; padding-left:18px; color:var(--exp-muted); font-size:.9rem; }
+#stb-express-root .stb-express-mode__card.is-active{
+  border-color:rgba(243,131,27,.55);
+  box-shadow:0 18px 36px rgba(243,131,27,.25);
+  transform:translateY(-4px);
+}
+#stb-express-root .stb-express-mode__card:not(.is-active):hover{
+  box-shadow:0 12px 26px rgba(16,18,33,.12);
+  transform:translateY(-3px);
+}
+
+#stb-express-root .stb-express-presets{ max-width:980px; margin:0 auto 36px; }
+#stb-express-root .stb-express-presets__header h2{ margin:0; font-size:1.6rem; }
+#stb-express-root .stb-express-presets__header p{ margin:6px 0 20px; color:var(--exp-muted); font-size:.98rem; }
+#stb-express-root .stb-express-presets__grid{ display:grid; gap:18px; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); }
+#stb-express-root .stb-express-preset{
+  border:1px solid var(--exp-line);
+  background:var(--exp-card);
+  border-radius:18px;
+  padding:20px;
+  text-align:left;
+  cursor:pointer;
+  position:relative;
+  display:grid;
+  gap:8px;
+  transition:box-shadow .2s, transform .2s, border-color .2s;
+}
+#stb-express-root .stb-express-preset__badge{
+  position:absolute;
+  top:18px;
+  right:18px;
+  background:var(--exp-accent);
+  color:#fff;
+  border-radius:999px;
+  padding:4px 10px;
+  font-size:.7rem;
+  font-weight:700;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+}
+#stb-express-root .stb-express-preset__name{ font-weight:700; font-size:1.05rem; }
+#stb-express-root .stb-express-preset__size{ color:var(--exp-muted); font-size:.9rem; }
+#stb-express-root .stb-express-preset__material{ color:#2f3342; font-size:.86rem; }
+#stb-express-root .stb-express-preset__price{ font-weight:700; color:var(--exp-accent-dark); font-size:.98rem; }
+#stb-express-root .stb-express-preset:hover{ box-shadow:0 14px 28px rgba(16,18,33,.14); transform:translateY(-4px); }
+#stb-express-root .stb-express-preset.is-active{ border-color:rgba(243,131,27,.65); box-shadow:0 18px 36px rgba(243,131,27,.28); }
+
+#stb-express-root .stb-express-step{
+  max-width:980px;
+  margin:0 auto 36px;
+  background:var(--exp-card);
+  border-radius:20px;
+  border:1px solid var(--exp-line);
+  padding:26px 28px 32px;
+  display:grid;
+  gap:20px;
+}
+#stb-express-root .stb-express-step__back{
+  border:none;
+  background:none;
+  color:var(--exp-accent-dark);
+  font-weight:700;
+  letter-spacing:.05em;
+  text-transform:uppercase;
+  cursor:pointer;
+  align-self:flex-start;
+}
+#stb-express-root .stb-express-step__header h2{ margin:0; font-size:1.55rem; }
+#stb-express-root .stb-express-step__meta{ margin:6px 0 0; color:var(--exp-muted); font-size:.92rem; }
+#stb-express-root .stb-express-step__meta .separator{ margin:0 6px; }
+#stb-express-root .stb-express-step__content{ display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:26px; }
+
+#stb-express-root .stb-express-qty{ display:flex; flex-wrap:wrap; gap:10px; margin:18px 0; }
+#stb-express-root .stb-express-qty__btn{
+  border:1px solid var(--exp-line);
+  background:#fff;
+  border-radius:999px;
+  padding:8px 18px;
+  font-weight:600;
+  cursor:pointer;
+  transition:box-shadow .18s, border-color .18s, transform .18s;
+}
+#stb-express-root .stb-express-qty__btn.is-active,
+#stb-express-root .stb-express-qty__btn[aria-pressed="true"]{
+  border-color:rgba(243,131,27,.65);
+  box-shadow:0 0 0 3px rgba(243,131,27,.2);
+}
+#stb-express-root .stb-express-qty__btn:hover{ transform:translateY(-2px); box-shadow:0 6px 16px rgba(16,18,33,.12); }
+
+#stb-express-root .stb-express-toggle{ display:grid; gap:8px; }
+#stb-express-root .stb-express-toggle__label{ display:flex; align-items:center; gap:10px; font-weight:700; }
+#stb-express-root .stb-express-toggle__label input{ width:18px; height:18px; accent-color:var(--exp-accent); }
+#stb-express-root .stb-express-toggle__hint{ margin:0; color:var(--exp-muted); font-size:.82rem; }
+#stb-express-root .stb-express-eta{ font-weight:700; font-size:.98rem; margin:18px 0 0; color:#20243a; }
+
+#stb-express-root .stb-express-form{ display:grid; gap:18px; }
+#stb-express-root .stb-express-upload__label{ font-weight:700; margin-bottom:6px; display:block; }
+#stb-express-root .stb-express-upload input[type="file"]{
+  width:100%;
+  border:1px dashed var(--exp-line);
+  border-radius:14px;
+  padding:18px;
+  background:#fafbff;
+}
+#stb-express-root .stb-express-upload__hint{ margin:8px 0 12px; font-size:.82rem; color:var(--exp-muted); }
+#stb-express-root .stb-express-preflight{ margin:0; padding-left:18px; display:grid; gap:6px; font-size:.82rem; color:#2f3342; }
+#stb-express-root .stb-preflight-item.is-ok{ color:#0f8a3b; }
+#stb-express-root .stb-preflight-item.is-warn{ color:#d68900; }
+#stb-express-root .stb-preflight-item.is-fail{ color:#c92a2a; }
+#stb-express-root .stb-preflight-item.is-info{ color:var(--exp-muted); }
+
+#stb-express-root .stb-express-summary{ display:grid; gap:12px; }
+#stb-express-root .stb-express-price{ font-size:1.14rem; font-weight:700; }
+#stb-express-root .stb-express-benefits{ margin:6px 0 0; padding-left:20px; font-size:.88rem; color:#2f3342; display:grid; gap:6px; }
+#stb-express-root .stb-express-error{ margin:0; color:#c92a2a; font-weight:600; min-height:1.2em; }
+#stb-express-root .stb-express-warning{ margin:0; font-size:.82rem; background:rgba(255,203,0,.15); border:1px solid rgba(255,203,0,.4); padding:10px 12px; border-radius:12px; color:#7a5a00; }
+
+#stb-express-root .stb-express-summary .btn{
+  border:none;
+  border-radius:999px;
+  padding:12px 24px;
+  font-weight:700;
+  font-size:1rem;
+  background:linear-gradient(90deg,#F3831B 0%,#FFCB00 100%);
+  color:#fff;
+  cursor:pointer;
+  transition:box-shadow .18s, transform .18s;
+}
+#stb-express-root .stb-express-summary .btn:hover{ transform:translateY(-2px); box-shadow:0 12px 24px rgba(243,131,27,.35); }
+#stb-express-root .stb-express-summary .btn:focus-visible{ outline:none; box-shadow:0 0 0 4px rgba(255,255,255,.6),0 0 0 6px rgba(243,131,27,.45); }
+
+#stb-express-root .stb-express-faq{ max-width:980px; margin:0 auto; background:var(--exp-card); border-radius:18px; border:1px solid var(--exp-line); padding:26px 28px; }
+#stb-express-root .stb-express-faq h2{ margin-top:0; font-size:1.4rem; }
+#stb-express-root .stb-express-faq dl{ margin:0; display:grid; gap:16px; }
+#stb-express-root .stb-express-faq dt{ font-weight:700; font-size:.94rem; text-transform:uppercase; letter-spacing:.08em; color:var(--exp-muted); }
+#stb-express-root .stb-express-faq dd{ margin:4px 0 0; font-size:.95rem; color:#2f3342; }
+
+#stb-express-root .stb-express-step.is-active{ animation:stbExpressFade .25s ease-out both; }
+@keyframes stbExpressFade{ from{ opacity:0; transform:translateY(12px); } to{ opacity:1; transform:translateY(0); } }
+
+@media (max-width:720px){
+  #stb-express-root{ padding:24px 12px 32px; }
+  #stb-express-root .stb-express-hero{ padding:24px; }
+  #stb-express-root .stb-express-hero__copy h1{ font-size:1.75rem; }
+  #stb-express-root .stb-express-mode__grid{ grid-template-columns:1fr; }
+  #stb-express-root .stb-express-presets__grid{ grid-template-columns:1fr; }
+  #stb-express-root .stb-express-step{ padding:22px 20px; }
+}
+
+#stb-root .stb-express-inline-hint{
+  margin-top:12px;
+  font-size:.82rem;
+  color:#596075;
+}
+#stb-root .stb-express-inline-hint a{
+  color:#F3831B;
+  font-weight:600;
+  text-decoration:none;
+}
+#stb-root .stb-express-inline-hint a:hover{ text-decoration:underline; }
+#stb-root .stb-lead-standard{ display:block; font-size:.88rem; color:#1f2435; }
+#stb-root .stb-express-inline-link{ display:block; margin-top:4px; font-size:.8rem; color:#596075; }
+#stb-root .stb-express-inline-link a{ color:#F3831B; font-weight:600; text-decoration:none; }
+#stb-root .stb-express-inline-link a:hover{ text-decoration:underline; }

--- a/assets/sticker-builder.js
+++ b/assets/sticker-builder.js
@@ -133,6 +133,10 @@
     }
     const FIELD = 'stb_payload';
     const CART_URL = (window.STB_CART_URL || '');
+    const STB_OPTIONS = window.STB_OPTIONS || {};
+    const EXPRESS_URL = (typeof STB_OPTIONS.express_url === 'string' && STB_OPTIONS.express_url)
+      ? STB_OPTIONS.express_url
+      : '/ekspres-48h/';
 
     const PDFLib = window.PDFLib || null;         // eksport PDF
     const QRCodeLib = window.QRCode || null;      // davidshimjs
@@ -2230,6 +2234,95 @@
       }
     }
 
+    const EXPRESS_TIMEZONE = 'Europe/Warsaw';
+
+    function expressToTimeZone(date){
+      const input = date instanceof Date ? new Date(date.getTime()) : new Date(date);
+      if (Number.isNaN(input.getTime())) return new Date();
+      const zoned = new Date(input.toLocaleString('en-US', { timeZone: EXPRESS_TIMEZONE }));
+      const diff = input.getTime() - zoned.getTime();
+      return new Date(input.getTime() - diff);
+    }
+
+    function expressIsWeekend(date){
+      const day = date.getDay();
+      return day === 0 || day === 6;
+    }
+
+    function expressEnsureBusiness(date){
+      const d = new Date(date.getTime());
+      while (expressIsWeekend(d)){
+        d.setDate(d.getDate() + 1);
+      }
+      return d;
+    }
+
+    function expressNextBusinessDay(date){
+      const d = new Date(date.getTime());
+      do {
+        d.setDate(d.getDate() + 1);
+      } while (expressIsWeekend(d));
+      return d;
+    }
+
+    function expressShipDate(options){
+      const opts = options || {};
+      const expressEnabled = opts.expressEnabled !== false;
+      let order = expressToTimeZone(opts.baseDate || new Date());
+      order = expressEnsureBusiness(order);
+      if (opts.assumeCutoff && order.getHours() >= 12){
+        order = expressEnsureBusiness(expressNextBusinessDay(order));
+        order.setHours(9, 0, 0, 0);
+      }
+      const cutoff = new Date(order.getTime());
+      cutoff.setHours(12, 0, 0, 0);
+      let ship = expressNextBusinessDay(order);
+      if (order.getTime() > cutoff.getTime()){
+        ship = expressNextBusinessDay(ship);
+      }
+      if (!expressEnabled){
+        ship = expressNextBusinessDay(ship);
+      }
+      ship = expressEnsureBusiness(ship);
+      ship.setHours(9, 0, 0, 0);
+      return ship;
+    }
+
+    function formatExpressShortDate(date){
+      try{
+        const formatter = new Intl.DateTimeFormat('pl-PL', {
+          timeZone: EXPRESS_TIMEZONE,
+          weekday: 'short',
+          day: '2-digit',
+          month: '2-digit'
+        });
+        const parts = formatter.formatToParts(date);
+        let weekday = '';
+        let day = '';
+        let month = '';
+        parts.forEach(part => {
+          if (part.type === 'weekday'){ weekday = part.value; }
+          if (part.type === 'day'){ day = part.value; }
+          if (part.type === 'month'){ month = part.value; }
+        });
+        weekday = weekday.replace(/\.$/, '').replace(/\s+/g, '');
+        const tidyWeek = weekday || formatter.format(date).split(',')[0].replace(/\.$/, '').trim();
+        const tidyDay = day || String(date.getDate()).padStart(2, '0');
+        const tidyMonth = month || String(date.getMonth() + 1).padStart(2, '0');
+        return `${tidyWeek}, ${tidyDay}.${tidyMonth}`;
+      }catch(err){
+        const weekdays = ['nd','pon','wt','śr','czw','pt','sob'];
+        const dd = String(date.getDate()).padStart(2,'0');
+        const mm = String(date.getMonth()+1).padStart(2,'0');
+        return `${weekdays[date.getDay()]}, ${dd}.${mm}`;
+      }
+    }
+
+    function expressEtaText(){
+      const ship = expressShipDate({ expressEnabled:true });
+      return 'Wysyłka: ' + formatExpressShortDate(ship) + ' • Dostawa +1 dzień';
+    }
+
     function updatePriceTimerDisplay(){
       if (!priceTimerEls.length) return;
       if (!priceTimerDeadline){
@@ -2279,7 +2372,11 @@
       const target = addBusinessDays(new Date(), days);
       const leadText = 'Wysyłka do ' + formatPLDateOnly(target);
       if (sumLeadtimeEl) sumLeadtimeEl.textContent = leadText;
-      totalLeadOutEls.forEach((el)=>{ el.textContent = leadText; });
+      const expressLabel = expressEtaText();
+      const expressLink = escapeAttr(EXPRESS_URL || '/ekspres-48h/');
+      const combinedHtml = `<span class="stb-lead-standard">${escapeHtml(leadText)}</span>` +
+        `<span class="stb-express-inline-link">Potrzebujesz szybciej? <a href="${expressLink}">Ekspres 48h (winyl)</a> — ${escapeHtml(expressLabel)}</span>`;
+      totalLeadOutEls.forEach((el)=>{ if (el) el.innerHTML = combinedHtml; });
     }
 
     // popup do wyceny

--- a/assets/sticker-express.js
+++ b/assets/sticker-express.js
@@ -1,0 +1,491 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    "use strict";
+
+    const root = document.getElementById('stb-express-root');
+    if (!root) return;
+
+    const TIMEZONE = 'Europe/Warsaw';
+    const VAT_RATE = 0.23;
+
+    function parseConfig(){
+      const raw = root.dataset.expressConfig;
+      if (!raw) return {};
+      try {
+        return JSON.parse(raw);
+      } catch(err){
+        console.error('[sticker-express] Nie można zdekodować konfiguracji', err);
+        return {};
+      }
+    }
+
+    const config = parseConfig();
+    const state = {
+      preset:null,
+      quantity:null,
+      express:true,
+      file:null
+    };
+
+    const presetList    = root.querySelector('[data-express-preset-list]');
+    const stepSection   = root.querySelector('[data-express-step]');
+    const qtyList       = root.querySelector('[data-express-qty-list]');
+    const toggle        = root.querySelector('#stb-express-toggle');
+    const etaEl         = root.querySelector('[data-express-eta]');
+    const priceEl       = root.querySelector('[data-express-price]');
+    const priceNetEl    = root.querySelector('[data-express-price-net]');
+    const payloadField  = root.querySelector('[data-express-payload]');
+    const errorEl       = root.querySelector('[data-express-error]');
+    const fileInput     = root.querySelector('[data-express-file]');
+    const preflightList = root.querySelector('[data-express-preflight]');
+    const backBtn       = root.querySelector('[data-express-back]');
+    const form          = root.querySelector('[data-express-form]');
+    const heroDeadline  = root.querySelector('[data-express-hero-deadline]');
+    const nameEl        = root.querySelector('[data-express-selected-name]');
+    const sizeEl        = root.querySelector('[data-express-selected-size]');
+    const materialEl    = root.querySelector('[data-express-selected-material]');
+
+    const allowedExt = Array.isArray(config.uploadExtensions) ? config.uploadExtensions.map(ext => String(ext).toLowerCase()) : ['pdf','ai','eps','svg'];
+    const expressSurcharge = Number(config.expressSurcharge) || 0;
+
+    function escapeHtml(value){
+      if (value == null) return '';
+      return String(value).replace(/[&<>"']/g, function(ch){
+        switch(ch){
+          case '&': return '&amp;';
+          case '<': return '&lt;';
+          case '>': return '&gt;';
+          case '"': return '&quot;';
+          default: return '&#039;';
+        }
+      });
+    }
+
+    function currencyContext(){
+      if (!config || typeof config.currency !== 'object') return { code:'PLN', symbol:'zł', position:'right', rate:1, locale:'pl-PL' };
+      const ctx = Object.assign({ code:'PLN', symbol:'zł', position:'right', rate:1, locale:'pl-PL' }, config.currency);
+      if (typeof ctx.code !== 'string' || !ctx.code){ ctx.code = 'PLN'; }
+      if (typeof ctx.symbol !== 'string' || !ctx.symbol){ ctx.symbol = ctx.code; }
+      const rate = Number(ctx.rate);
+      ctx.rate = Number.isFinite(rate) && rate > 0 ? rate : 1;
+      if (typeof ctx.position !== 'string' || !ctx.position){ ctx.position = 'right'; }
+      if (typeof ctx.locale !== 'string' || !ctx.locale){ ctx.locale = 'pl-PL'; }
+      return ctx;
+    }
+
+    const currency = currencyContext();
+
+    function formatPrice(amount){
+      const base = Number(amount);
+      const converted = Number.isFinite(base) ? base * currency.rate : 0;
+      let numberStr;
+      try {
+        numberStr = new Intl.NumberFormat(currency.locale, { minimumFractionDigits:2, maximumFractionDigits:2 }).format(converted);
+      } catch(err){
+        numberStr = converted.toFixed(2);
+      }
+      const symbol = currency.symbol || currency.code || 'PLN';
+      const position = String(currency.position || 'right').toLowerCase();
+      const hasSpace = position.includes('space');
+      const spacer = hasSpace ? '&nbsp;' : '';
+      const numberHtml = escapeHtml(numberStr);
+      const symbolHtml = `<span class="woocommerce-Price-currencySymbol">${escapeHtml(symbol)}</span>`;
+      let body;
+      if (position.startsWith('left')){
+        body = `${symbolHtml}${spacer}${numberHtml}`;
+      } else if (position.startsWith('right')){
+        body = `${numberHtml}${spacer}${symbolHtml}`;
+      } else {
+        body = `${numberHtml}${spacer}${symbolHtml}`;
+      }
+      return `<span class="woocommerce-Price-amount amount"><bdi>${body}</bdi></span>`;
+    }
+
+    function pushEvent(name, detail){
+      if (!name) return;
+      const eventName = detail && detail.event ? detail.event : name;
+      const payload = Object.assign({ event: eventName }, detail || {});
+      if (Array.isArray(window.dataLayer)){
+        window.dataLayer.push(payload);
+      } else {
+        window.dataLayer = [ payload ];
+      }
+    }
+
+    function toTimeZone(date, timeZone){
+      const input = date instanceof Date ? new Date(date.getTime()) : new Date(date);
+      if (Number.isNaN(input.getTime())) return new Date();
+      const parts = new Date(input.toLocaleString('en-US', { timeZone }));
+      const diff = input.getTime() - parts.getTime();
+      return new Date(input.getTime() - diff);
+    }
+
+    function isWeekend(date){
+      const day = date.getDay();
+      return day === 0 || day === 6;
+    }
+
+    function ensureBusiness(date){
+      const d = new Date(date.getTime());
+      while (isWeekend(d)){
+        d.setDate(d.getDate() + 1);
+      }
+      return d;
+    }
+
+    function nextBusinessDay(date){
+      const d = new Date(date.getTime());
+      do {
+        d.setDate(d.getDate() + 1);
+      } while (isWeekend(d));
+      return d;
+    }
+
+    function computeExpressShipDate(options){
+      const opts = options || {};
+      const expressEnabled = opts.expressEnabled !== false;
+      let order = toTimeZone(opts.baseDate || new Date(), TIMEZONE);
+      order = ensureBusiness(order);
+
+      if (opts.assumeCutoff && order.getHours() >= 12){
+        order = ensureBusiness(nextBusinessDay(order));
+        order.setHours(9, 0, 0, 0);
+      }
+
+      const cutoff = new Date(order.getTime());
+      cutoff.setHours(12, 0, 0, 0);
+
+      let ship = nextBusinessDay(order);
+      if (order.getTime() > cutoff.getTime()){
+        ship = nextBusinessDay(ship);
+      }
+
+      if (!expressEnabled){
+        ship = nextBusinessDay(ship);
+      }
+
+      ship = ensureBusiness(ship);
+      ship.setHours(9, 0, 0, 0);
+      return ship;
+    }
+
+    function formatShortDate(date){
+      try {
+        const formatter = new Intl.DateTimeFormat('pl-PL', {
+          timeZone: TIMEZONE,
+          weekday: 'short',
+          day: '2-digit',
+          month: '2-digit'
+        });
+        const parts = formatter.formatToParts(date);
+        let weekday = '';
+        let day = '';
+        let month = '';
+        parts.forEach(function(part){
+          if (part.type === 'weekday'){ weekday = part.value; }
+          if (part.type === 'day'){ day = part.value; }
+          if (part.type === 'month'){ month = part.value; }
+        });
+        weekday = weekday.replace(/\.$/, '').replace(/\s+/g, '');
+        if (!weekday){
+          const fallback = formatter.format(date).split(',')[0] || '';
+          weekday = fallback.replace(/\.$/, '').trim();
+        }
+        const tidyWeekday = weekday || '';
+        const tidyDay = day || String(date.getDate()).padStart(2, '0');
+        const tidyMonth = month || String(date.getMonth() + 1).padStart(2, '0');
+        return `${tidyWeekday}, ${tidyDay}.${tidyMonth}`;
+      } catch(err){
+        const weekdays = ['nd', 'pon', 'wt', 'śr', 'czw', 'pt', 'sob'];
+        const dd = String(date.getDate()).padStart(2, '0');
+        const mm = String(date.getMonth() + 1).padStart(2, '0');
+        return `${weekdays[date.getDay()]}, ${dd}.${mm}`;
+      }
+    }
+
+    function formatEta(shipDate, expressEnabled){
+      const tidy = formatShortDate(shipDate);
+      if (expressEnabled){
+        return `Wysyłka: ${tidy} • Dostawa +1 dzień`;
+      }
+      return `Standard: ${tidy} • Dostawa +1–2 dni`;
+    }
+
+    function updateHeroDeadline(){
+      if (!heroDeadline) return;
+      const ship = computeExpressShipDate({ assumeCutoff:true, expressEnabled:true });
+      heroDeadline.textContent = formatShortDate(ship);
+    }
+
+    function presetButtons(){
+      if (!presetList) return [];
+      return Array.from(presetList.querySelectorAll('.stb-express-preset'));
+    }
+
+    function highlightPreset(id){
+      presetButtons().forEach(btn => {
+        if (!(btn instanceof HTMLElement)) return;
+        const match = btn.dataset.presetId === id;
+        btn.classList.toggle('is-active', match);
+        btn.setAttribute('aria-pressed', match ? 'true' : 'false');
+      });
+    }
+
+    function renderQuantities(preset){
+      if (!qtyList) return;
+      qtyList.innerHTML = '';
+      if (!preset || !Array.isArray(preset.quantities)) return;
+      preset.quantities.forEach((qty)=>{
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'stb-express-qty__btn';
+        btn.textContent = `${qty} szt.`;
+        btn.dataset.qty = String(qty);
+        btn.setAttribute('aria-pressed', state.quantity === qty ? 'true' : 'false');
+        btn.addEventListener('click', function(){
+          selectQuantity(qty);
+        });
+        qtyList.appendChild(btn);
+      });
+    }
+
+    function computeBaseTotal(preset, quantity){
+      if (!preset) return 0;
+      const idx = Array.isArray(preset.quantities) ? preset.quantities.indexOf(quantity) : -1;
+      const multiplier = Array.isArray(preset.multipliers) && idx >= 0 ? Number(preset.multipliers[idx]) : 1;
+      const basePrice = Number(preset.basePrice) || 0;
+      const factor = Number.isFinite(multiplier) && multiplier > 0 ? multiplier : 1;
+      return basePrice * factor;
+    }
+
+    function computeTotals(){
+      if (!state.preset || !state.quantity) return null;
+      const baseTotal = computeBaseTotal(state.preset, state.quantity);
+      let gross = baseTotal;
+      if (state.express){
+        gross = baseTotal * (1 + expressSurcharge);
+      }
+      const net = gross / (1 + VAT_RATE);
+      return { base: baseTotal, gross, net };
+    }
+
+    function updatePrice(){
+      const totals = computeTotals();
+      if (!totals){
+        if (priceEl) priceEl.textContent = '—';
+        if (priceNetEl) priceNetEl.textContent = '';
+        return;
+      }
+      if (priceEl){
+        priceEl.innerHTML = formatPrice(totals.gross);
+      }
+      if (priceNetEl){
+        priceNetEl.innerHTML = `<span class="stb-price-prefix">Netto:</span> ${formatPrice(totals.net)}`;
+      }
+    }
+
+    function updateEta(){
+      if (!etaEl) return;
+      if (!state.preset || !state.quantity){
+        etaEl.textContent = 'Wysyłka: —';
+        return;
+      }
+      const ship = computeExpressShipDate({ expressEnabled: state.express });
+      etaEl.textContent = formatEta(ship, state.express);
+    }
+
+    function updatePreflight(file){
+      if (!preflightList) return;
+      preflightList.innerHTML = '';
+      const items = [];
+      if (file){
+        const ext = file.name.includes('.') ? file.name.split('.').pop().toLowerCase() : '';
+        const ok = allowedExt.includes(ext);
+        items.push({
+          status: ok ? 'ok' : 'fail',
+          text: ok ? `Format: ${ext.toUpperCase()} — OK` : `Format ${ext ? ext.toUpperCase() : '—'} nieobsługiwany`
+        });
+      } else {
+        items.push({ status:'warn', text:'Dodaj plik w PDF / AI / EPS / SVG.' });
+      }
+      items.push({ status:'info', text:'Sprawdź spad 2 mm i kolory CMYK przed wysyłką.' });
+      items.push({ status:'info', text:'Teksty na krzywych, minimalny element ≥15–20 mm.' });
+
+      items.forEach(item => {
+        const li = document.createElement('li');
+        li.className = `stb-preflight-item is-${item.status}`;
+        li.textContent = item.text;
+        preflightList.appendChild(li);
+      });
+    }
+
+    function clearError(){
+      if (errorEl) errorEl.textContent = '';
+    }
+
+    function showError(message){
+      if (errorEl){
+        errorEl.textContent = message;
+      }
+    }
+
+    function selectQuantity(qty){
+      state.quantity = qty;
+      if (state.preset && Array.isArray(state.preset.quantities)){
+        state.preset.quantities.forEach((value)=>{
+          const btn = qtyList ? qtyList.querySelector(`[data-qty="${value}"]`) : null;
+          if (btn){
+            btn.classList.toggle('is-active', value === qty);
+            btn.setAttribute('aria-pressed', value === qty ? 'true' : 'false');
+          }
+        });
+      }
+      updatePrice();
+      updateEta();
+      clearError();
+    }
+
+    function selectPreset(preset){
+      if (!preset) return;
+      state.preset = preset;
+      state.quantity = Array.isArray(preset.quantities) ? preset.quantities[0] : null;
+      state.express = true;
+      if (toggle){
+        toggle.checked = true;
+      }
+      if (nameEl) nameEl.textContent = preset.name || '';
+      if (sizeEl) sizeEl.textContent = preset.size || '';
+      if (materialEl) materialEl.textContent = preset.material || '';
+      renderQuantities(preset);
+      selectQuantity(state.quantity);
+      updateEta();
+      updatePrice();
+      updatePreflight(state.file);
+      highlightPreset(preset.id);
+      if (stepSection){
+        stepSection.hidden = false;
+        stepSection.classList.add('is-active');
+        if (typeof stepSection.scrollIntoView === 'function'){
+          stepSection.scrollIntoView({ behavior:'smooth', block:'start' });
+        }
+      }
+      pushEvent('stb_express_preset_click', {
+        event: config.analyticsPrefix ? `${config.analyticsPrefix}_preset_click` : 'stb_express_preset_click',
+        preset_id: preset.id,
+        preset_name: preset.name
+      });
+    }
+
+    if (presetList){
+      presetList.addEventListener('click', function(event){
+        const target = event.target.closest('.stb-express-preset');
+        if (!target) return;
+        const raw = target.dataset.preset;
+        if (!raw) return;
+        try {
+          const preset = JSON.parse(raw);
+          preset.quantities = Array.isArray(preset.quantities) ? preset.quantities.map(Number) : [];
+          preset.multipliers = Array.isArray(preset.multipliers) ? preset.multipliers.map(Number) : [];
+          selectPreset(preset);
+        } catch(err){
+          console.error('[sticker-express] Nie można odczytać preset', err);
+        }
+      });
+    }
+
+    if (backBtn){
+      backBtn.addEventListener('click', function(){
+        if (stepSection){
+          stepSection.hidden = true;
+          stepSection.classList.remove('is-active');
+        }
+        state.preset = null;
+        state.quantity = null;
+        highlightPreset('');
+      });
+    }
+
+    if (toggle){
+      toggle.addEventListener('change', function(){
+        state.express = toggle.checked;
+        updatePrice();
+        updateEta();
+        pushEvent('stb_express_toggle', {
+          event: config.analyticsPrefix ? `${config.analyticsPrefix}_toggle` : 'stb_express_toggle',
+          express_enabled: state.express
+        });
+      });
+    }
+
+    if (fileInput){
+      fileInput.addEventListener('change', function(){
+        state.file = fileInput.files && fileInput.files[0] ? fileInput.files[0] : null;
+        updatePreflight(state.file);
+        pushEvent('stb_express_upload', {
+          event: config.analyticsPrefix ? `${config.analyticsPrefix}_upload` : 'stb_express_upload',
+          file_name: state.file ? state.file.name : null,
+          file_type: state.file ? state.file.type : null
+        });
+      });
+      updatePreflight(null);
+    }
+
+    if (form){
+      form.addEventListener('submit', function(event){
+        clearError();
+        if (!state.preset || !state.quantity){
+          event.preventDefault();
+          showError('Wybierz preset oraz nakład.');
+          return;
+        }
+        if (!state.file){
+          event.preventDefault();
+          showError('Dodaj plik do druku (PDF, AI, EPS, SVG).');
+          return;
+        }
+        if (!payloadField){
+          return;
+        }
+        const totals = computeTotals();
+        const ship = computeExpressShipDate({ expressEnabled: state.express });
+        const payload = {
+          mode: 'express-48h',
+          preset_id: state.preset.id,
+          preset_name: state.preset.name,
+          size: state.preset.size,
+          material: state.preset.material,
+          quantity: state.quantity,
+          express_enabled: state.express,
+          express_surcharge: expressSurcharge,
+          base_price_pln: totals ? Number(totals.base) : 0,
+          total_price_pln: totals ? Number(totals.gross) : 0,
+          eta: {
+            label: formatEta(ship, state.express),
+            ship_date: ship.toISOString()
+          },
+          currency: currency,
+          upload: state.file ? {
+            name: state.file.name,
+            size: state.file.size,
+            type: state.file.type
+          } : null,
+          generated_at: new Date().toISOString()
+        };
+        try {
+          payloadField.value = JSON.stringify(payload);
+        } catch(err){
+          console.error('[sticker-express] Nie można serializować payload', err);
+          payloadField.value = '';
+        }
+        pushEvent('stb_express_add_to_cart', {
+          event: config.analyticsPrefix ? `${config.analyticsPrefix}_add_to_cart` : 'stb_express_add_to_cart',
+          preset_id: state.preset.id,
+          quantity: state.quantity,
+          express_enabled: state.express
+        });
+      });
+    }
+
+    updateHeroDeadline();
+  });
+})();

--- a/sticker-builder.php
+++ b/sticker-builder.php
@@ -12,9 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 final class WC_Sticker_Builder {
 
     const FIELD = 'stb_payload';
+    const EXPRESS_SURCHARGE = 0.15;
 
     public static function init() {
         add_shortcode( 'sticker_builder', [ __CLASS__, 'render_shortcode' ] );
+        add_shortcode( 'sticker_express', [ __CLASS__, 'render_express_shortcode' ] );
         add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
 
         add_filter( 'woocommerce_add_cart_item_data', [ __CLASS__, 'add_cart_item_data' ], 10, 3 );
@@ -24,91 +26,32 @@ final class WC_Sticker_Builder {
         add_filter( 'woocommerce_add_to_cart_redirect', [ __CLASS__, 'maybe_redirect_to_cart' ] );
     }
 
-    public static function plugin_path( $append = '' ) {
-        $base = plugin_dir_path( __FILE__ );
-        return $append ? $base . ltrim( $append, '/\\' ) : $base;
+    private static function page_has_shortcode( $shortcode ) {
+        if ( empty( $shortcode ) || ! function_exists( 'has_shortcode' ) ) {
+            return false;
+        }
+
+        if ( ! class_exists( 'WP_Post' ) ) {
+            return false;
+        }
+
+        $post = get_post();
+        if ( ! $post instanceof WP_Post ) {
+            return false;
+        }
+
+        if ( has_shortcode( $post->post_content, $shortcode ) ) {
+            return true;
+        }
+
+        if ( ! empty( $post->post_excerpt ) && has_shortcode( $post->post_excerpt, $shortcode ) ) {
+            return true;
+        }
+
+        return false;
     }
 
-    public static function plugin_url( $append = '' ) {
-        $base = plugin_dir_url( __FILE__ );
-        return $append ? $base . ltrim( $append, '/\\' ) : $base;
-    }
-
-    public static function enqueue_assets() {
-        if ( ! is_product() ) { return; }
-
-        /* ===== CSS ===== */
-        $css_rel = 'assets/sticker-builder.css';
-        $css_abs = self::plugin_path( $css_rel );
-        $ver_css = file_exists( $css_abs ) ? filemtime( $css_abs ) : '1.0.0';
-        wp_enqueue_style( 'sticker-builder', self::plugin_url( $css_rel ), [], $ver_css );
-
-        /* ===== JS vendor: PDF-Lib (eksport PDF) ===== */
-        $pdf_lib_rel = 'assets/vendor/pdf-lib.min.js';
-        $pdf_lib_abs = self::plugin_path( $pdf_lib_rel );
-        if ( file_exists( $pdf_lib_abs ) ) {
-            wp_enqueue_script(
-                'stb-pdf-lib',
-                self::plugin_url( $pdf_lib_rel ),
-                [],
-                filemtime( $pdf_lib_abs ) ?: '1.17.1',
-                true
-            );
-        }
-
-        /* ===== JS vendor: PDF.js (podgląd PDF w canvasie) =====
-           Używamy buildów UMD: pdf.min.js + pdf.worker.min.js w tym samym katalogu. */
-        $pdfjs_rel_dir   = 'assets/vendor/pdfjs/';
-        $pdfjs_main_rel  = $pdfjs_rel_dir . 'pdf.min.js';
-        $pdfjs_worker_rel= $pdfjs_rel_dir . 'pdf.worker.min.js';
-        $pdfjs_main_abs  = self::plugin_path( $pdfjs_main_rel );
-        $pdfjs_worker_abs= self::plugin_path( $pdfjs_worker_rel );
-        $have_pdfjs = file_exists( $pdfjs_main_abs ) && file_exists( $pdfjs_worker_abs );
-
-        if ( $have_pdfjs ) {
-            wp_enqueue_script(
-                'stb-pdfjs',
-                self::plugin_url( $pdfjs_main_rel ),
-                [],
-                filemtime( $pdfjs_main_abs ) ?: '4.6.82',
-                true
-            );
-            // Ustaw poprawny workerSrc, żeby PDF.js mógł wczytać worker z tej samej wtyczki:
-            $worker_url = self::plugin_url( $pdfjs_worker_rel );
-            $inline = 'if (window.pdfjsLib && window.pdfjsLib.GlobalWorkerOptions) { window.pdfjsLib.GlobalWorkerOptions.workerSrc = "'. esc_url( $worker_url ) .'"; }';
-            wp_add_inline_script( 'stb-pdfjs', $inline, 'after' );
-        }
-
-        /* ===== (Opcjonalnie) QRCode (davidshimjs) ===== */
-        $qr_rel = 'assets/vendor/qrcode.min.js';
-        $qr_abs = self::plugin_path( $qr_rel );
-        $have_qr = file_exists( $qr_abs );
-        if ( $have_qr ) {
-            wp_enqueue_script(
-                'stb-qrcodejs',
-                self::plugin_url( $qr_rel ),
-                [],
-                filemtime( $qr_abs ) ?: '1.0.0',
-                true
-            );
-        }
-
-        /* ===== Główny skrypt ===== */
-        $main_rel = 'assets/sticker-builder.js';
-        $main_abs = self::plugin_path( $main_rel );
-        $deps = [];
-        if ( file_exists( $pdf_lib_abs ) ) { $deps[] = 'stb-pdf-lib'; }
-        if ( $have_pdfjs )               { $deps[] = 'stb-pdfjs'; }
-        if ( $have_qr )                  { $deps[] = 'stb-qrcodejs'; }
-
-        wp_enqueue_script(
-            'sticker-builder',
-            self::plugin_url( $main_rel ),
-            $deps,
-            file_exists( $main_abs ) ? filemtime( $main_abs ) : '1.0.0',
-            true
-        );
-
+    private static function current_currency_context() {
         $currency_code = 'PLN';
         if ( function_exists( 'woocs_get_current_currency' ) ) {
             $currency_code = woocs_get_current_currency();
@@ -143,17 +86,135 @@ final class WC_Sticker_Builder {
         }
         $locale = sanitize_text_field( $locale );
 
-        wp_localize_script(
-            'sticker-builder',
-            'STB_CURR',
-            [
-                'code'     => $currency_code,
-                'symbol'   => $currency_symbol,
-                'position' => $currency_position,
-                'rate'     => floatval( $rate ),
-                'locale'   => $locale,
-            ]
-        );
+        return [
+            'code'     => $currency_code,
+            'symbol'   => $currency_symbol,
+            'position' => $currency_position,
+            'rate'     => floatval( $rate ),
+            'locale'   => $locale,
+        ];
+    }
+
+    public static function plugin_path( $append = '' ) {
+        $base = plugin_dir_path( __FILE__ );
+        return $append ? $base . ltrim( $append, '/\\' ) : $base;
+    }
+
+    public static function plugin_url( $append = '' ) {
+        $base = plugin_dir_url( __FILE__ );
+        return $append ? $base . ltrim( $append, '/\\' ) : $base;
+    }
+
+    public static function enqueue_assets() {
+        $has_builder = is_product() || self::page_has_shortcode( 'sticker_builder' );
+        $has_express = self::page_has_shortcode( 'sticker_express' );
+
+        if ( ! $has_builder && ! $has_express ) {
+            return;
+        }
+
+        /* ===== CSS ===== */
+        $css_rel = 'assets/sticker-builder.css';
+        $css_abs = self::plugin_path( $css_rel );
+        $ver_css = file_exists( $css_abs ) ? filemtime( $css_abs ) : '1.0.0';
+        wp_enqueue_style( 'sticker-builder', self::plugin_url( $css_rel ), [], $ver_css );
+
+        if ( $has_builder ) {
+            /* ===== JS vendor: PDF-Lib (eksport PDF) ===== */
+            $pdf_lib_rel = 'assets/vendor/pdf-lib.min.js';
+            $pdf_lib_abs = self::plugin_path( $pdf_lib_rel );
+            if ( file_exists( $pdf_lib_abs ) ) {
+                wp_enqueue_script(
+                    'stb-pdf-lib',
+                    self::plugin_url( $pdf_lib_rel ),
+                    [],
+                    filemtime( $pdf_lib_abs ) ?: '1.17.1',
+                    true
+                );
+            }
+
+            /* ===== JS vendor: PDF.js (podgląd PDF w canvasie) =====
+               Używamy buildów UMD: pdf.min.js + pdf.worker.min.js w tym samym katalogu. */
+            $pdfjs_rel_dir   = 'assets/vendor/pdfjs/';
+            $pdfjs_main_rel  = $pdfjs_rel_dir . 'pdf.min.js';
+            $pdfjs_worker_rel= $pdfjs_rel_dir . 'pdf.worker.min.js';
+            $pdfjs_main_abs  = self::plugin_path( $pdfjs_main_rel );
+            $pdfjs_worker_abs= self::plugin_path( $pdfjs_worker_rel );
+            $have_pdfjs = file_exists( $pdfjs_main_abs ) && file_exists( $pdfjs_worker_abs );
+
+            if ( $have_pdfjs ) {
+                wp_enqueue_script(
+                    'stb-pdfjs',
+                    self::plugin_url( $pdfjs_main_rel ),
+                    [],
+                    filemtime( $pdfjs_main_abs ) ?: '4.6.82',
+                    true
+                );
+                // Ustaw poprawny workerSrc, żeby PDF.js mógł wczytać worker z tej samej wtyczki:
+                $worker_url = self::plugin_url( $pdfjs_worker_rel );
+                $inline = 'if (window.pdfjsLib && window.pdfjsLib.GlobalWorkerOptions) { window.pdfjsLib.GlobalWorkerOptions.workerSrc = "'. esc_url( $worker_url ) .'"; }';
+                wp_add_inline_script( 'stb-pdfjs', $inline, 'after' );
+            }
+
+            /* ===== (Opcjonalnie) QRCode (davidshimjs) ===== */
+            $qr_rel = 'assets/vendor/qrcode.min.js';
+            $qr_abs = self::plugin_path( $qr_rel );
+            $have_qr = file_exists( $qr_abs );
+            if ( $have_qr ) {
+                wp_enqueue_script(
+                    'stb-qrcodejs',
+                    self::plugin_url( $qr_rel ),
+                    [],
+                    filemtime( $qr_abs ) ?: '1.0.0',
+                    true
+                );
+            }
+
+            /* ===== Główny skrypt ===== */
+            $main_rel = 'assets/sticker-builder.js';
+            $main_abs = self::plugin_path( $main_rel );
+            $deps = [];
+            if ( file_exists( $pdf_lib_abs ) ) { $deps[] = 'stb-pdf-lib'; }
+            if ( $have_pdfjs )               { $deps[] = 'stb-pdfjs'; }
+            if ( $have_qr )                  { $deps[] = 'stb-qrcodejs'; }
+
+            wp_enqueue_script(
+                'sticker-builder',
+                self::plugin_url( $main_rel ),
+                $deps,
+                file_exists( $main_abs ) ? filemtime( $main_abs ) : '1.0.0',
+                true
+            );
+
+            wp_localize_script(
+                'sticker-builder',
+                'STB_CURR',
+                self::current_currency_context()
+            );
+
+            $express_url = home_url( '/ekspres-48h/' );
+            wp_localize_script(
+                'sticker-builder',
+                'STB_OPTIONS',
+                [
+                    'express_url' => esc_url_raw( $express_url ),
+                ]
+            );
+        }
+
+        if ( $has_express ) {
+            $express_rel = 'assets/sticker-express.js';
+            $express_abs = self::plugin_path( $express_rel );
+            if ( file_exists( $express_abs ) ) {
+                wp_enqueue_script(
+                    'sticker-express',
+                    self::plugin_url( $express_rel ),
+                    [],
+                    filemtime( $express_abs ) ?: '1.0.0',
+                    true
+                );
+            }
+        }
     }
 
     public static function render_shortcode( $atts = [], $content = '' ) {
@@ -163,6 +224,137 @@ final class WC_Sticker_Builder {
             include $tpl;
         } else {
             echo '<p>Brak pliku szablonu konfiguratora.</p>';
+        }
+        return ob_get_clean();
+    }
+
+    private static function express_presets_data() {
+        return [
+            [
+                'id'         => '7050-vinyl',
+                'name'       => 'Etykieta 70×50 mm',
+                'size'       => '70×50 mm',
+                'material'   => 'Winyl biały (bez laminacji)',
+                'quantities' => [ 500, 1000, 2000 ],
+                'base_price' => 149,
+            ],
+            [
+                'id'         => '9060-vinyl',
+                'name'       => 'Etykieta 90×60 mm',
+                'size'       => '90×60 mm',
+                'material'   => 'Winyl biały (bez laminacji)',
+                'quantities' => [ 500, 1000, 2000 ],
+                'base_price' => 189,
+            ],
+            [
+                'id'         => '6060-vinyl',
+                'name'       => 'Etykieta 60×60 mm',
+                'size'       => '60×60 mm',
+                'material'   => 'Winyl biały (bez laminacji)',
+                'quantities' => [ 500, 1000, 2000 ],
+                'base_price' => 129,
+            ],
+            [
+                'id'         => '50round-vinyl',
+                'name'       => 'Koło Ø50 mm',
+                'size'       => 'Ø 50 mm',
+                'material'   => 'Winyl biały (bez laminacji)',
+                'quantities' => [ 500, 1000, 2000 ],
+                'base_price' => 159,
+            ],
+            [
+                'id'         => '100150-vinyl',
+                'name'       => 'Etykieta 100×150 mm',
+                'size'       => '100×150 mm',
+                'material'   => 'Winyl biały (bez laminacji)',
+                'quantities' => [ 250, 500, 1000 ],
+                'base_price' => 169,
+            ],
+        ];
+    }
+
+    private static function express_quantity_multipliers( $count ) {
+        $defaults = [ 1.0, 1.7, 3.1, 4.6, 6.2 ];
+        if ( $count <= 0 ) {
+            return [];
+        }
+        if ( $count <= count( $defaults ) ) {
+            return array_slice( $defaults, 0, $count );
+        }
+        $result = $defaults;
+        while ( count( $result ) < $count ) {
+            $result[] = end( $result ) + 1.4;
+        }
+        return $result;
+    }
+
+    private static function express_standard_url() {
+        return home_url( '/produkt/naklejki-kalkulator/' );
+    }
+
+    private static function build_express_config( $product_id ) {
+        $presets = [];
+        foreach ( self::express_presets_data() as $preset ) {
+            $quantities = array_map( 'intval', $preset['quantities'] );
+            $multipliers = self::express_quantity_multipliers( count( $quantities ) );
+            $presets[] = [
+                'id'          => sanitize_key( $preset['id'] ),
+                'name'        => sanitize_text_field( $preset['name'] ),
+                'size'        => sanitize_text_field( $preset['size'] ),
+                'material'    => sanitize_text_field( $preset['material'] ),
+                'quantities'  => $quantities,
+                'basePrice'   => floatval( $preset['base_price'] ),
+                'multipliers' => array_map( 'floatval', $multipliers ),
+            ];
+        }
+
+        $currency = self::current_currency_context();
+
+        return [
+            'presets'           => $presets,
+            'expressSurcharge'  => self::EXPRESS_SURCHARGE,
+            'currency'          => $currency,
+            'cartUrl'           => function_exists( 'wc_get_cart_url' ) ? wc_get_cart_url() : '',
+            'productId'         => absint( $product_id ),
+            'expressUrl'        => home_url( '/ekspres-48h/' ),
+            'standardUrl'       => self::express_standard_url(),
+            'uploadExtensions'  => [ 'pdf', 'ai', 'eps', 'svg' ],
+            'analyticsPrefix'   => 'stb_express',
+        ];
+    }
+
+    public static function render_express_shortcode( $atts = [], $content = '' ) {
+        $atts = shortcode_atts(
+            [
+                'product_id' => '',
+                'product'    => '',
+                'class'      => '',
+            ],
+            $atts,
+            'sticker_express'
+        );
+
+        $product_id = absint( $atts['product_id'] );
+        if ( ! $product_id ) {
+            $product_id = absint( $atts['product'] );
+        }
+
+        if ( ! $product_id && class_exists( 'WC_Product' ) ) {
+            global $product;
+            if ( $product instanceof WC_Product ) {
+                $product_id = $product->get_id();
+            }
+        }
+
+        $wrapper_class = trim( sanitize_text_field( $atts['class'] ) );
+        $express_config = self::build_express_config( $product_id );
+
+        ob_start();
+        $tpl = self::plugin_path( 'templates/express.php' );
+        if ( file_exists( $tpl ) ) {
+            include $tpl;
+        } else {
+            echo '<p>Brak szablonu ekspresowego.</p>';
         }
         return ob_get_clean();
     }

--- a/templates/builder.php
+++ b/templates/builder.php
@@ -74,8 +74,15 @@ $stb_zero_net_markup = sprintf(
     esc_html__( 'Netto:', 'sticker-builder' ),
     $stb_zero_price_markup
 );
+
+$stb_express_url = esc_url( home_url( '/ekspres-48h/' ) );
 ?>
 <div id="stb-root">
+    <div class="stb-standard-banner" role="note">
+        <strong>Potrzebujesz szybciej?</strong>
+        <span>Ekspresowe presety winylowe wysyłamy w 48h.</span>
+        <a href="<?php echo $stb_express_url; ?>">Ekspres 48h (winyl)</a>
+    </div>
     <div class="stb-wrap">
         <div class="stb-steps">
             <div class="stb-card stb-step is-active" id="stb-step-1" aria-hidden="false">
@@ -202,6 +209,7 @@ $stb_zero_net_markup = sprintf(
                         <div class="total-net" id="stb-total-net" data-stb-total-net><?php echo wp_kses_post( $stb_zero_net_markup ); ?></div>
                         <div class="total-save" id="stb-total-save" data-stb-total-save aria-live="polite"></div>
                     </div>
+                    <p class="stb-express-inline-hint">Ekspres dotyczy tylko presetów w trybie 48h – laminacja dostępna w trybie standard (eco-solvent: odgazowanie; latex/UV: +12–24 h).</p>
                 </div>
                 <div class="step-footer">
                     <button type="button" class="btn btn-primary btn-step" id="stb-step1-next">Dalej</button>

--- a/templates/express.php
+++ b/templates/express.php
@@ -1,0 +1,173 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$express_config = isset( $express_config ) && is_array( $express_config ) ? $express_config : [];
+$wrapper_class  = isset( $wrapper_class ) ? $wrapper_class : '';
+$express_json   = wp_json_encode( $express_config );
+if ( false === $express_json ) {
+    $express_json = '{}';
+}
+
+$classes = trim( 'stb-express-root ' . $wrapper_class );
+$standard_url = ! empty( $express_config['standardUrl'] ) ? esc_url( $express_config['standardUrl'] ) : '#';
+$currency_symbol = isset( $express_config['currency']['symbol'] ) ? $express_config['currency']['symbol'] : 'zł';
+$currency_code   = isset( $express_config['currency']['code'] ) ? $express_config['currency']['code'] : 'PLN';
+
+$format_price = function( $amount ) use ( $express_config, $currency_symbol, $currency_code ) {
+    $amount = floatval( $amount );
+    if ( function_exists( 'wc_price' ) ) {
+        return wc_price( $amount );
+    }
+    $formatted = number_format_i18n( $amount, 2 );
+    $symbol    = $currency_symbol ? $currency_symbol : $currency_code;
+    return esc_html( $formatted . ' ' . $symbol );
+};
+?>
+<div id="stb-express-root" class="<?php echo esc_attr( $classes ); ?>" data-express-config="<?php echo esc_attr( $express_json ); ?>">
+    <section class="stb-express-hero">
+        <div class="stb-express-hero__copy">
+            <h1>Winylowe etykiety wodoodporne? <strong>Wysyłka w 48h</strong></h1>
+            <p class="stb-express-hero__lead">Zamów do <strong>12:00</strong> — nadamy <span data-express-hero-deadline>najbliższy dzień roboczy</span>.</p>
+            <ul class="stb-express-hero__sla" aria-label="Warunki SLA">
+                <li>Format z listy</li>
+                <li>Gotowy plik do druku</li>
+                <li>Płatność online</li>
+                <li><strong>Bez laminacji w ekspresie</strong></li>
+            </ul>
+        </div>
+    </section>
+
+    <section class="stb-express-mode" aria-label="Wybór trybu">
+        <div class="stb-express-mode__grid">
+            <div class="stb-express-mode__card is-active" aria-pressed="true">
+                <header>
+                    <p class="stb-express-mode__eyebrow">Ekspres 48h</p>
+                    <h2>Presety • pewny termin</h2>
+                </header>
+                <ul>
+                    <li>Stałe formaty na winylu</li>
+                    <li>Cutoff: zamów do 12:00</li>
+                    <li>Dopłata ekspres: +15%</li>
+                </ul>
+            </div>
+            <a class="stb-express-mode__card" href="<?php echo $standard_url; ?>">
+                <header>
+                    <p class="stb-express-mode__eyebrow">Tryb standard</p>
+                    <h2>Dowolne kształty/opcje + laminacja</h2>
+                </header>
+                <p>Pełny konfigurator • terminy standard</p>
+            </a>
+        </div>
+    </section>
+
+    <section class="stb-express-presets" aria-label="Presety ekspresowe">
+        <header class="stb-express-presets__header">
+            <h2>Wybierz format z listy</h2>
+            <p>Stałe konfiguracje na winylu — tylko kilka kliknięć do koszyka.</p>
+        </header>
+        <div class="stb-express-presets__grid" data-express-preset-list>
+            <?php if ( ! empty( $express_config['presets'] ) ) : ?>
+                <?php foreach ( $express_config['presets'] as $preset ) :
+                    $preset_quantities = isset( $preset['quantities'] ) ? array_map( 'intval', (array) $preset['quantities'] ) : [];
+                    $preset_price      = isset( $preset['basePrice'] ) ? floatval( $preset['basePrice'] ) : 0;
+                    $preset_id         = isset( $preset['id'] ) ? $preset['id'] : '';
+                    $multipliers       = isset( $preset['multipliers'] ) ? array_map( 'floatval', (array) $preset['multipliers'] ) : [];
+                    ?>
+                    <button type="button"
+                        class="stb-express-preset"
+                        data-preset-id="<?php echo esc_attr( $preset_id ); ?>"
+                        data-preset='<?php echo esc_attr( wp_json_encode( [
+                            'id'          => $preset_id,
+                            'name'        => $preset['name'],
+                            'size'        => $preset['size'],
+                            'material'    => $preset['material'],
+                            'quantities'  => $preset_quantities,
+                            'basePrice'   => $preset_price,
+                            'multipliers' => $multipliers,
+                        ] ) ); ?>'>
+                        <span class="stb-express-preset__badge">48h</span>
+                        <span class="stb-express-preset__name"><?php echo esc_html( $preset['name'] ); ?></span>
+                        <span class="stb-express-preset__size"><?php echo esc_html( $preset['size'] ); ?></span>
+                        <span class="stb-express-preset__material"><?php echo esc_html( $preset['material'] ); ?></span>
+                        <span class="stb-express-preset__price">od <?php echo $format_price( $preset_price ); ?></span>
+                    </button>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </div>
+    </section>
+
+    <section class="stb-express-step" data-express-step hidden>
+        <button type="button" class="stb-express-step__back" data-express-back>← Wróć do listy presetów</button>
+        <header class="stb-express-step__header">
+            <h2 data-express-selected-name>Wybierz preset</h2>
+            <p class="stb-express-step__meta">
+                <span data-express-selected-size></span>
+                <span class="separator">•</span>
+                <span data-express-selected-material></span>
+            </p>
+        </header>
+        <div class="stb-express-step__content">
+            <div class="stb-express-step__left">
+                <h3>1. Nakład</h3>
+                <div class="stb-express-qty" data-express-qty-list aria-label="Dostępne nakłady"></div>
+                <div class="stb-express-toggle">
+                    <label class="stb-express-toggle__label">
+                        <input type="checkbox" id="stb-express-toggle" checked aria-describedby="stb-express-toggle-hint">
+                        <span>Ekspres 48h (+15%)</span>
+                    </label>
+                    <p id="stb-express-toggle-hint" class="stb-express-toggle__hint">Domyślnie aktywny — gwarantuje wysyłkę w 48h.</p>
+                </div>
+                <p class="stb-express-eta" data-express-eta>Wysyłka: —</p>
+            </div>
+            <div class="stb-express-step__right">
+                <form class="stb-express-form" method="post" enctype="multipart/form-data" data-express-form>
+                    <?php wp_nonce_field( 'stb_express_submit', 'stb_express_nonce' ); ?>
+                    <?php if ( ! empty( $express_config['productId'] ) ) : ?>
+                        <input type="hidden" name="add-to-cart" value="<?php echo esc_attr( $express_config['productId'] ); ?>" data-express-product>
+                    <?php endif; ?>
+                    <input type="hidden" name="<?php echo esc_attr( WC_Sticker_Builder::FIELD ); ?>" value="" data-express-payload>
+                    <div class="stb-express-upload">
+                        <label for="stb-express-file" class="stb-express-upload__label">2. Dodaj plik do druku</label>
+                        <input type="file" id="stb-express-file" name="stb_express_file" accept=".pdf,.ai,.eps,.svg" data-express-file>
+                        <p class="stb-express-upload__hint">Spad <strong>2 mm</strong>, <strong>CMYK</strong>, teksty na krzywych; obrys cięcia (<code>CutContour</code>) dla kształtów nieregularnych. Minimalny element ≥15–20 mm, odstęp od linii cięcia ≥1,5 mm.</p>
+                        <ul class="stb-express-preflight" data-express-preflight aria-live="polite"></ul>
+                    </div>
+                    <div class="stb-express-summary">
+                        <?php if ( empty( $express_config['productId'] ) ) : ?>
+                            <p class="stb-express-warning">Uwaga: przypisz produkt WooCommerce do shortcodu <code>[sticker_express]</code>, aby włączyć dodawanie do koszyka.</p>
+                        <?php endif; ?>
+                        <div class="stb-express-price" data-express-price>—</div>
+                        <div class="stb-express-price" data-express-price-net></div>
+                        <ul class="stb-express-benefits">
+                            <li><strong>Wodoodporne</strong> – na szkło, plastik, metal</li>
+                            <li><strong>Mocny klej (szary)</strong> – mniejsze przebijanie tła</li>
+                            <li><strong>Outdoor-ready</strong> – krótko/średnioterminowe ekspozycje</li>
+                        </ul>
+                        <p class="stb-express-error" data-express-error aria-live="assertive"></p>
+                        <button type="submit" class="btn btn-primary stb-express-submit">Dodaj do koszyka</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </section>
+
+    <section class="stb-express-faq" aria-label="FAQ ekspres 48h">
+        <h2>FAQ 48h</h2>
+        <dl>
+            <div>
+                <dt>Cutoff zamówień</dt>
+                <dd><strong>Do 12:00</strong> w dni robocze. Po 12:00 liczymy jako złożone następnego dnia.</dd>
+            </div>
+            <div>
+                <dt>Warunki 48h</dt>
+                <dd>Preset z listy, gotowy plik, płatność online, <strong>bez laminacji</strong>.</dd>
+            </div>
+            <div>
+                <dt>Dostawa</dt>
+                <dd>Wysyłka w 48h, doręczenie zwykle następnego dnia roboczego (Kurier / InPost).</dd>
+            </div>
+        </dl>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- add a dedicated Ekspres 48h – Winyl landing template with preset cards, ETA logic, upload checks and cart payload submission
- enqueue the new flow through a shortcode plus currency-aware config in the plugin while keeping standard builder assets scoped
- surface the express option from the standard builder via a banner, inline hint and ETA messaging tied into the updated JS helpers

## Testing
- php -l sticker-builder.php
- php -l templates/express.php

------
https://chatgpt.com/codex/tasks/task_e_68ed264efc2c8333aa85e5d754e942c0